### PR TITLE
Update efym.net image to sha-62f8e439a33c34ff7b6add7002b24fe6578b1db7

### DIFF
--- a/kubernetes/apps/efym-net/deployment.yaml
+++ b/kubernetes/apps/efym-net/deployment.yaml
@@ -21,4 +21,4 @@ spec:
     spec:
       containers:
       - name: efym-net
-        image: ghcr.io/tw1zr99/efym.net:latest
+        image: ghcr.io/tw1zr99/efym.net:sha-62f8e43


### PR DESCRIPTION
Automated update of efym.net image tag to:
```
ghcr.io/tw1zr99/efym.net:sha-62f8e439a33c34ff7b6add7002b24fe6578b1db7
```
Triggered by changes to the efym.net repository.