### PR TITLE
Update efym.net image to sha-de0c99fdd21cbf6016f6bb3901c1a621f9cc8791

### DIFF
--- a/kubernetes/apps/efym-net/deployment.yaml
+++ b/kubernetes/apps/efym-net/deployment.yaml
@@ -28,7 +28,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: efym-net
-        image: ghcr.io/tw1zr99/efym.net:sha-0b56bcb2e0c294af7e1171023e3a7dfe0f1f1cc0
+        image: ghcr.io/tw1zr99/efym.net:sha-de0c99fdd21cbf6016f6bb3901c1a621f9cc8791
         # securityContext:
         #   runAsNonRoot: false
         #   # runAsUser: 1000


### PR DESCRIPTION
Automated update of efym.net image tag to:
```
ghcr.io/tw1zr99/efym.net:sha-de0c99fdd21cbf6016f6bb3901c1a621f9cc8791
```
Triggered by changes to the efym.net repository.